### PR TITLE
Fix RFC3339 parsing for timestamps with fractional seconds

### DIFF
--- a/luatz/parse.lua
+++ b/luatz/parse.lua
@@ -6,7 +6,7 @@ local new_timetable = require "luatz.timetable".new
 -- If the timestamp is only partial (i.e. missing "Z" or time offset) then `tz_offset` will be nil
 -- TODO: Validate components are within their boundarys (e.g. 1 <= month <= 12)
 local function rfc_3339(str, init)
-	local year, month, day, hour, min, sec, patt_end = str:match("^(%d%d%d%d)%-(%d%d)%-(%d%d)[Tt](%d%d%.?%d*):(%d%d):(%d%d)()", init) -- luacheck: ignore 631
+	local year, month, day, hour, min, sec, patt_end = str:match("^(%d%d%d%d)%-(%d%d)%-(%d%d)[Tt](%d%d):(%d%d):(%d%d%.?%d*)()", init) -- luacheck: ignore 631
 	if not year then
 		return nil, "Invalid RFC 3339 timestamp"
 	end
@@ -15,7 +15,7 @@ local function rfc_3339(str, init)
 	day   = tonumber(day, 10)
 	hour  = tonumber(hour, 10)
 	min   = tonumber(min, 10)
-	sec   = tonumber(sec, 10)
+	sec   = tonumber(sec)  -- Allow fractional seconds
 
 	local tt = new_timetable(year, month, day, hour, min, sec)
 

--- a/spec/parse_spec.lua
+++ b/spec/parse_spec.lua
@@ -11,6 +11,12 @@ describe("Time parsing library", function()
 		-- Missing offsets parse
 		assert.same(timetable.new(2013,10,22,14,17,02), (parse.rfc_3339 "2013-10-22T14:17:02"))
 
+		-- Fractional seconds (milliseconds) with Z suffix
+		assert.same({timetable.new(2013,10,22,14,17,2.123), 0}, {parse.rfc_3339 "2013-10-22T14:17:02.123Z"})
+
+		-- Fractional seconds with numeric offset
+		assert.same({timetable.new(2013,10,22,14,17,2.456), -5*3600}, {parse.rfc_3339 "2013-10-22T14:17:02.456-05:00"})
+
 		-- Invalid
 		assert.same(nil, (parse.rfc_3339 "an invalid timestamp"))
 	end)


### PR DESCRIPTION
Previously, the decimal pattern (%.?%d*) was incorrectly placed in the hour field of the regex pattern, causing it to:
1. Capture fractional parts in the wrong field (e.g., "00.51" for hour)
2. Position patt_end incorrectly, making timezone suffix detection fail
3. Return nil for tz_offset when parsing timestamps like "2025-10-19T00:51:15.095Z"

This fix:
1. Moves the decimal pattern from hour to seconds field in the regex
2. Changes tonumber(sec, 10) to tonumber(sec) to properly parse fractional values
3. Adds test cases for timestamps with milliseconds and various timezone offsets

Impact: This bug caused timestamps with fractional seconds (common in APIs like Google Calendar) to fail parsing, returning nil offset instead of 0 for UTC timestamps, breaking timestamp comparison logic in applications.

Test cases added:
- Fractional seconds with Z suffix: "2013-10-22T14:17:02.123Z"
- Fractional seconds with numeric offset: "2013-10-22T14:17:02.456-05:00"